### PR TITLE
Create custom Axios instance to handle CSRF, credentials, base API URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.14.15",
         "axios": "^1.6.1",
+        "js-cookie": "^3.0.5",
         "prettier": "^3.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2149,9 +2150,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -4003,6 +4004,14 @@
         "has-symbols": "^1.0.3",
         "reflect.getprototypeof": "^1.0.4",
         "set-function-name": "^2.0.1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -7173,9 +7182,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -8532,6 +8541,11 @@
         "reflect.getprototypeof": "^1.0.4",
         "set-function-name": "^2.0.1"
       }
+    },
+    "js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.14.15",
     "axios": "^1.6.1",
+    "js-cookie": "^3.0.5",
     "prettier": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/common/CustomAxios.jsx
+++ b/src/common/CustomAxios.jsx
@@ -1,0 +1,24 @@
+import axios from "axios";
+import Cookies from "js-cookie";
+import { API_BASE_URL } from "../config/AppConstant.js";
+
+const customAxios = axios.create({
+    baseURL: API_BASE_URL,
+    withCredentials: true,
+    headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+});
+
+customAxios.interceptors.request.use((config) => {
+    const csrfToken = Cookies.get("csrftoken");
+    if (csrfToken) {
+        config.headers["X-CSRFToken"] = csrfToken;
+    }
+    return config;
+}, (error) => {
+    return Promise.reject(error);
+});
+
+export default customAxios;

--- a/src/config/AppConstant.js
+++ b/src/config/AppConstant.js
@@ -1,9 +1,12 @@
-const API_BASE_URL = "http://localhost:8000/";
-const CREATE_ACCOUNT_URL = API_BASE_URL + "signup/"
-const LOGIN_ACCOUNT_URL = API_BASE_URL + "login/"
+const API_BASE_URL = import.meta.env.DEV ? "http://localhost:8000/" : "https://api.key-fortress.com/";
+const CREATE_ACCOUNT_URL = "signup/";
+const LOGIN_ACCOUNT_URL = "login/";
+const LOGOUT_ACCOUNT_URL = "logout";
 
 
 export {
+    API_BASE_URL,
     CREATE_ACCOUNT_URL,
-    LOGIN_ACCOUNT_URL
+    LOGIN_ACCOUNT_URL,
+    LOGOUT_ACCOUNT_URL
 }


### PR DESCRIPTION
## Changes

- Added a module `CustomAxios` that exports a pre-configured `axios` instance that handles:
     - Setting the base API URL
     - Setting and passing credentials
     - Setting the `X-CSRFToken` header with the current value of the `csrftoken` cookie (needed for POST, PUT, PATCH, and DELETE requests on all API endpoints except `/signup` and `/login`)
- Dynamically set `API_BASE_URL` in `src/config/AppConstant.js` based on whether Vite is running in dev or prod

## Usage

- Import from the `CustomAxios` module rather than `axios` itself
```js
import { default as axios } from "../common/CustomAxios.jsx";
```
- Pass the relative URL and the data object in the axios call
```js
axios.post(
     'login/', 
     {
          "email": "bob@example.com",
          "password": "SZsd7f98b2FMmG92/HeCseFFRba0d87ba2Das="
     }
);
```

## Manual testing

- Temporarily added the following code to the Dashboard component:
```js
useEffect(() => {
      axios.post('login/', {"email": "bob@example.com",
          "password": "SZsd7f98b2FMmG92/HeCseFFRba0d87ba2Das="}).then(response => {
              console.log(response.status);
              axios.post('logout/').then(response => console.log(response.status))
      });
  }, []);
```
- Request to `/login` (which does not require session or CSRF tokens). Server response sets the `sessionid` and `csrftoken` cookies:

<img width="882" alt="Screenshot 2023-11-15 at 2 39 13 PM" src="https://github.com/secure-password-manager/PasswordManagerWeb/assets/39425112/704877a0-a5f8-4984-88c8-b47d64064864">

- Request to `/logout` (which requires the `sessionid` and `csrftoken` cookies in the `Cookie` header and the `csrftoken` cookie in the `X-CSRFToken` header). Correct values are passed back to server:

<img width="808" alt="Screenshot 2023-11-15 at 2 39 25 PM" src="https://github.com/secure-password-manager/PasswordManagerWeb/assets/39425112/f5488633-bba4-4c06-b293-6a9711b6a70c">

Closes #37 #39 