### PR TITLE
Store symmetricKey in global state, get user data on DashboardPage load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
+        "zustand": "^4.4.6",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -6068,6 +6069,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
@@ -6389,6 +6398,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
+      "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zxcvbn": {
@@ -10648,6 +10684,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "vite": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
@@ -10833,6 +10875,14 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
+      "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     },
     "zxcvbn": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
+    "zustand": "^4.4.6",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/src/common/ServerAPI.jsx
+++ b/src/common/ServerAPI.jsx
@@ -1,5 +1,6 @@
 import { default as axios } from "../common/CustomAxios";
 import {
+  base64ToArrayBuffer,
   decryptSymmetricKey,
   decryptVaultItem,
   deriveMasterKey,
@@ -35,8 +36,8 @@ async function loginAccount(email, password) {
   const response = await axios.post(
     LOGIN_ACCOUNT_URL,
     {
-        email: email,
-        password: passwordHash,
+      email: email,
+      password: passwordHash,
     },
   );
 
@@ -55,7 +56,7 @@ async function getUserData(symmetricKey) {
   const collections = collectionResponse.data;
   let items = itemResponse.data;
 
-  items = await decryptItems(items, symmetricKey);
+  items = await decryptItems(items, base64ToArrayBuffer(symmetricKey));
 
   return {collections, items};
 }

--- a/src/common/ServerAPI.jsx
+++ b/src/common/ServerAPI.jsx
@@ -68,6 +68,7 @@ async function decryptItems(items, symmetricKey) {
   }
 
   return items;
+
 }
 
 export { createAccount, getUserData, loginAccount };

--- a/src/common/useGlobalStore.jsx
+++ b/src/common/useGlobalStore.jsx
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+export const useGlobalStore = create((set) => ({
+  symmetricKey: null,
+  setSymmetricKey: (symmetricKey) =>
+    set((state) => ({
+      ...state,
+      symmetricKey: symmetricKey,
+    })),
+  deleteSymmetricKey: () =>
+    set((state) => ({
+      ...state,
+      symmetricKey: null,
+    })),
+}));

--- a/src/common/useGlobalStore.jsx
+++ b/src/common/useGlobalStore.jsx
@@ -1,15 +1,20 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
-export const useGlobalStore = create((set) => ({
-  symmetricKey: null,
-  setSymmetricKey: (symmetricKey) =>
-    set((state) => ({
-      ...state,
-      symmetricKey: symmetricKey,
-    })),
-  deleteSymmetricKey: () =>
-    set((state) => ({
-      ...state,
-      symmetricKey: null,
-    })),
-}));
+export const useGlobalStore = create(
+  persist((set) => ({
+    symmetricKey: "",
+    setSymmetricKey: (symmetricKey) => {
+      set((state) => ({
+        ...state,
+        symmetricKey: symmetricKey,
+      }))},
+    deleteSymmetricKey: () =>
+      set((state) => ({
+        ...state,
+        symmetricKey: "",
+      })),
+  }), {
+  name: "key-fortress"
+  })
+);

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -107,9 +107,9 @@ function LoginForm() {
     }
 
     try {
-      const symmetricKey = await loginAccount(email, password);
+      const response = await loginAccount(email, password);
       alert("Logging into account");
-      navigate("/dashboard", { state: { symmetricKey: symmetricKey } });
+      navigate("/dashboard");
     } catch (error) {
       setPasswordError(loginError);
       setEmailError(loginError);

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -2,9 +2,11 @@ import React, { useState } from "react";
 import { Tab, Tabs, TextField, Stack, Button, Container } from "@mui/material";
 import { Box } from "@mui/system";
 import { useNavigate } from "react-router-dom";
+
 import { createAccount, loginAccount } from "../common/ServerAPI";
-import PasswordStrength from "@/components/PasswordStrength";
 import BasicTabs from "./NavBar";
+import PasswordStrength from "../components/PasswordStrength";
+import { useGlobalStore } from "../common/useGlobalStore";
 
 const errorMessages = {
   mismatch: "Passwords do not match",
@@ -48,6 +50,7 @@ function LoginForm() {
     useState(clearError);
 
   const navigate = useNavigate();
+  const setSymmetricKey = useGlobalStore((state) => state.setSymmetricKey)
 
   const handleTabChange = (event, tabIndex) => {
     setCurrentTabIndex(tabIndex);
@@ -107,7 +110,8 @@ function LoginForm() {
     }
 
     try {
-      const response = await loginAccount(email, password);
+      const symmetricKey = await loginAccount(email, password);
+      setSymmetricKey(symmetricKey);
       alert("Logging into account");
       navigate("/dashboard");
     } catch (error) {

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -7,6 +7,7 @@ import { createAccount, loginAccount } from "../common/ServerAPI";
 import BasicTabs from "./NavBar";
 import PasswordStrength from "../components/PasswordStrength";
 import { useGlobalStore } from "../common/useGlobalStore";
+import { arrayBufferToBase64 } from "../lib/encryption";
 
 const errorMessages = {
   mismatch: "Passwords do not match",
@@ -50,7 +51,7 @@ function LoginForm() {
     useState(clearError);
 
   const navigate = useNavigate();
-  const setSymmetricKey = useGlobalStore((state) => state.setSymmetricKey)
+  const setSymmetricKey = useGlobalStore((state) => state.setSymmetricKey);
 
   const handleTabChange = (event, tabIndex) => {
     setCurrentTabIndex(tabIndex);
@@ -111,7 +112,7 @@ function LoginForm() {
 
     try {
       const symmetricKey = await loginAccount(email, password);
-      setSymmetricKey(symmetricKey);
+      setSymmetricKey(arrayBufferToBase64(symmetricKey));
       alert("Logging into account");
       navigate("/dashboard");
     } catch (error) {

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -107,9 +107,9 @@ function LoginForm() {
     }
 
     try {
-      const response = await loginAccount(email, password);
+      const symmetricKey = await loginAccount(email, password);
       alert("Logging into account");
-      navigate("/dashboard");
+      navigate("/dashboard", { state: { symmetricKey: symmetricKey } });
     } catch (error) {
       setPasswordError(loginError);
       setEmailError(loginError);

--- a/src/routers/DashboardPage.jsx
+++ b/src/routers/DashboardPage.jsx
@@ -1,26 +1,13 @@
-import React, { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import React from "react";
 
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import { Box, Typography } from "@mui/material";
 import VaultItemTiles from "../components/VaultItemTiles";
-import { getUserData } from "../common/ServerAPI";
+
+import { collections, items } from "../config/data/splitSampleData";
 
 function DashboardPage() {
-  const location = useLocation();
-  const [collections, setCollections] = useState([]);
-  const [items, setItems] = useState({});
-  
-  const symmetricKey = location.state.symmetricKey;
-
-  useEffect(() => {
-      getUserData(symmetricKey).then((data) => {
-          setCollections(data.collections);
-          setItems(data.items);
-      })
-  },[]);
-
   return (
     <>
       <NavBar />

--- a/src/routers/DashboardPage.jsx
+++ b/src/routers/DashboardPage.jsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Outlet, Link } from "react-router-dom";
-
+import { Outlet, Link, useLocation } from "react-router-dom";
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import { Box, Typography } from "@mui/material";
@@ -9,6 +8,10 @@ import { collections, items } from "../config/data/splitSampleData";
 import NewItemForm from "../components/NewItemForm";
 
 function DashboardPage() {
+  const location = useLocation();
+  const symmetricKey = location.state.symmetricKey;
+  console.log(`symmetric key from location state: ${symmetricKey}`);
+
   return (
     <>
       <NavBar />

--- a/src/routers/DashboardPage.jsx
+++ b/src/routers/DashboardPage.jsx
@@ -1,13 +1,24 @@
-import React from "react";
-
+import React, { useEffect, useState } from "react";
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import { Box, Typography } from "@mui/material";
 import VaultItemTiles from "../components/VaultItemTiles";
 
-import { collections, items } from "../config/data/splitSampleData";
+import { getUserData } from "../common/ServerAPI";
+import { useGlobalStore } from "../common/useGlobalStore";
 
 function DashboardPage() {
+  const [collections, setCollections] = useState([]);
+  const [items, setItems] = useState({});
+  const symmetricKey = useGlobalStore((state) => state.symmetricKey);
+
+  useEffect(() => {
+    getUserData(symmetricKey).then((data) => {
+      setCollections(data.collections);
+      setItems(data.items);
+    });
+  }, [symmetricKey]);
+
   return (
     <>
       <NavBar />

--- a/src/routers/DashboardPage.jsx
+++ b/src/routers/DashboardPage.jsx
@@ -1,16 +1,25 @@
-import React from "react";
-import { Outlet, Link, useLocation } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import { Box, Typography } from "@mui/material";
 import VaultItemTiles from "../components/VaultItemTiles";
-import { collections, items } from "../config/data/splitSampleData";
-import NewItemForm from "../components/NewItemForm";
+import { getUserData } from "../common/ServerAPI";
 
 function DashboardPage() {
   const location = useLocation();
+  const [collections, setCollections] = useState([]);
+  const [items, setItems] = useState({});
+  
   const symmetricKey = location.state.symmetricKey;
-  console.log(`symmetric key from location state: ${symmetricKey}`);
+
+  useEffect(() => {
+      getUserData(symmetricKey).then((data) => {
+          setCollections(data.collections);
+          setItems(data.items);
+      })
+  },[]);
 
   return (
     <>

--- a/src/routers/DashboardPage.jsx
+++ b/src/routers/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Outlet, Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";

--- a/src/routers/DashboardPage.jsx
+++ b/src/routers/DashboardPage.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react";
+import { Outlet, Link, useNavigate } from "react-router-dom";
+
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import { Box, Typography } from "@mui/material";
@@ -11,12 +13,22 @@ function DashboardPage() {
   const [collections, setCollections] = useState([]);
   const [items, setItems] = useState({});
   const symmetricKey = useGlobalStore((state) => state.symmetricKey);
+  const navigate = useNavigate();
 
   useEffect(() => {
-    getUserData(symmetricKey).then((data) => {
-      setCollections(data.collections);
-      setItems(data.items);
-    });
+    getUserData(symmetricKey)
+      .then((data) => {
+        setCollections(data.collections);
+        setItems(data.items);
+      })
+      .catch((error) => {
+        if(error.response && error.response.status) {
+          if(error.response.status === 403) {
+            navigate('/login-signup');
+          }
+        }
+      }
+    );
   }, [symmetricKey]);
 
   return (


### PR DESCRIPTION
Note: this PR depends on #53 "Get and decrypt user data"

## Changes

- Establish `globalStore` for storing global state in local storage using Zustand
- Set `symmetricKey` in `globalStore` on login
- On `DashboardPage` load:
     - Retrieve `symmetricKey` from `globalStore`
     - Get user data from server
     - Set `collections` and `items` in local state
- Redirect unauthenticated users from DashboardPage to login-signup

## Testing
Use temporary console.log statements to show `symmetricKey` and data object with `collections` and `items` loaded in DashboardPage. 

Collections "Default" and "Work" are also shown in the collections list on the page

<img width="1185" alt="Screenshot 2023-11-23 at 7 30 53 PM" src="https://github.com/secure-password-manager/PasswordManagerWeb/assets/39425112/2af423ba-87e3-4f19-8a71-6441f0d0d202">

Closes #54 #55 