### PR TITLE
Add method to check if password has been compromised

### DIFF
--- a/src/common/Compromised.jsx
+++ b/src/common/Compromised.jsx
@@ -1,0 +1,31 @@
+import axios from "axios";
+import { generateSHA1Hash } from "../lib/encryption.ts";
+
+const PWNED_API_URL = "https://api.pwnedpasswords.com/range/";
+
+async function checkIsPasswordCompromised(password) {
+  const hash = await generateSHA1Hash(password);
+  const shortHash = hash.substring(0, 5);
+  const hashSuffix = hash.substring(5).toUpperCase();
+
+  try {
+    const response = await axios.get(`${PWNED_API_URL}${shortHash}`);
+
+    if(response.data) {
+      const results = response.data.split('\r\n');
+
+      for(const result of results) {
+        const [hashResult, numCompromises] = result.split(':');
+        if(hashResult === hashSuffix) {
+          return numCompromises;
+        }
+      }
+    }
+    return "0";
+  }
+  catch (error) {
+    return "-1";
+  }
+}
+
+export { checkIsPasswordCompromised };

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -73,6 +73,16 @@ export const generateSymmetricKey = () : ArrayBuffer => {
     return getRandomBytes(32).buffer;
 }
 
+/* Adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest */
+export const generateSHA1Hash = async (password : string) : Promise<string> => {
+    const data = encoder.encode(password);
+    const hash = await window.crypto.subtle.digest('SHA-1', data);
+    const hashArray = Array.from(new Uint8Array(hash));
+    return hashArray
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")
+}
+
 const cryptoKeyFromKeyBuffer = async (key : ArrayBuffer, usages : Array<KeyUsage>) : Promise<CryptoKey> => {
     const keyAlgorithmParams : AesKeyGenParams = {
         name: 'AES-GCM',


### PR DESCRIPTION
Add method that checks the [Pwned Passwords API](https://haveibeenpwned.com/API/v3#PwnedPasswords) to see if the user's password has been compromised in a breach.

Accepts password string as a parameter, and returns a string representing the number of times a password has been compromised.

Will return "-1" if there's any error calling the API, so when calling the method you should check for this value and possibly return a "Service not available" message.

```js
const numCompromises = await checkIsPasswordCompromised("password");
console.log(numCompromises); // "9659365"
```