### PR TITLE
Add state mutation functions for collections and items

### DIFF
--- a/src/common/stateMutation.jsx
+++ b/src/common/stateMutation.jsx
@@ -1,0 +1,37 @@
+function setItem(itemData, setItems) {
+  setItems(items => ({
+    ...items,
+    [itemData.uuid]: itemData
+  }))
+}
+
+function deleteItem(itemData, setItems) {
+  console.log(itemData)
+  setItems(items => {
+    const {[itemData.uuid]: _, ...rest} = items;
+    return rest;
+  })
+}
+
+function createCollection(collectionData, setCollections) {
+  setCollections(collections => [
+    ...collections,
+    collectionData
+  ])
+}
+
+function updateCollection(collectionData, setCollections) {
+  setCollections(collections => collections.map(
+    collection => collection.uuid === collectionData.uuid ? collectionData : collection)
+  )
+}
+
+function deleteCollection(collectionData, setCollections, setItems) {
+  setCollections(collections => collections.filter(collection => collection.uuid !== collectionData.uuid));
+  setItems((items) => Object.keys(items)
+                            .filter(key => items[key]["vault_collection"] !== collectionData.uuid)
+                            .reduce( (result, key) => (result[key] = items[key], result), {} )
+  );
+}
+
+export { setItem, deleteItem, createCollection, updateCollection, deleteCollection }

--- a/src/common/stateMutation.jsx
+++ b/src/common/stateMutation.jsx
@@ -6,7 +6,6 @@ function setItem(itemData, setItems) {
 }
 
 function deleteItem(itemData, setItems) {
-  console.log(itemData)
   setItems(items => {
     const {[itemData.uuid]: _, ...rest} = items;
     return rest;

--- a/test/mutationData.js
+++ b/test/mutationData.js
@@ -1,0 +1,53 @@
+export const newItemData = {
+  data: {
+    name: "Los Angeles Times",
+    url: "https://latimes.com",
+    username: "bob@example.com",
+    password: "ccY2d4OadYkGtHgOHe",
+  },
+  uuid: "de6e1413-4ac6-4e29-9e6d-780587f39871",
+  vault_collection: "44fc3cb7-efea-42a6-aa31-0bf06b0c9f82",
+  created_at: "2023-11-22T19:44:29.280574Z",
+  modified_at: "2023-11-22T20:10:03.285150Z",
+};
+
+export const updatedItemData = {
+  data: {
+    name: "Mastodon",
+    url: "https://mstdn.social",
+    username: "bob@example.com",
+    password: "Mvkza4enJUK6KbW1oV",
+  },
+  uuid: "e7ca3b88-5250-41c4-bc8d-817ff0a81576",
+  vault_collection: "1b7c8ea1-41e6-4415-8a38-5da9f36e4255",
+  created_at: "2023-11-22T19:44:11.387882Z",
+  modified_at: "2023-11-22T20:09:31.632502Z",
+};
+
+export const existingItemData = {
+  data: {
+    name: "New York Times",
+    url: "https://nytimes.com",
+    username: "bob@example.com",
+    password: "V4TQhBZRnGmVNYenw",
+  },
+  uuid: "c7a3a041-8c76-44ed-ba6c-0a0a4be67823",
+  vault_collection: "44fc3cb7-efea-42a6-aa31-0bf06b0c9f82",
+  created_at: "2023-11-22T19:44:29.280574Z",
+  modified_at: "2023-11-22T20:10:03.285150Z",
+}
+
+export const newCollectionData = {
+  name: "Sports",
+  uuid: "af3f5518-f09e-4c22-82c9-58c3623651a4",
+}
+
+export const updatedCollectionData = {
+  name: "Newspapers",
+  uuid: "44fc3cb7-efea-42a6-aa31-0bf06b0c9f82",
+}
+
+export const existingCollectionData = {
+  name: "Finance",
+  uuid: "8acbe9de-1aef-4a33-9d17-8f2b6a79a349",
+}

--- a/test/stateMutation.test.js
+++ b/test/stateMutation.test.js
@@ -5,7 +5,8 @@ import {
   newItemData,
   updatedItemData,
   newCollectionData,
-  updatedCollectionData, existingCollectionData
+  updatedCollectionData,
+  existingCollectionData
 } from "./mutationData.js";
 
 import { setItem, deleteItem, createCollection, updateCollection, deleteCollection } from "@/common/stateMutation.jsx";
@@ -28,18 +29,21 @@ beforeEach(() => {
 
 describe('item mutators', () => {
   it('setItem should add a new item to the state', () => {
+    expect(Object.keys(items).length).toEqual(9);
     setItem(newItemData, setMockItems);
     expect(Object.keys(newItems).length).toEqual(10);
     expect(newItemData.uuid in newItems).toBe(true);
   })
 
   it('setItem should update an item in the state', () => {
+    expect(Object.keys(items).length).toEqual(9);
     setItem(updatedItemData, setMockItems);
     expect(Object.keys(newItems).length).toEqual(9);
     expect(newItems[updatedItemData.uuid].data.password).toEqual(updatedItemData.data.password);
   })
 
   it('deleteItem should delete an item from the state', () => {
+    expect(Object.keys(items).length).toEqual(9);
     deleteItem(existingItemData, setMockItems);
     expect(Object.keys(newItems).length).toEqual(8);
     expect(existingItemData.uuid in newItems).toBe(false);
@@ -48,12 +52,14 @@ describe('item mutators', () => {
 
 describe('collection mutators', () => {
   it('createCollection should add a new collection to the state', () => {
+    expect(collections.length).toEqual(3);
     createCollection(newCollectionData, setMockCollections);
     expect(newCollections.length).toEqual(4);
     expect(newCollections.filter(collection => collection.uuid === newCollectionData.uuid).length).toEqual(1);
   })
 
   it('updateCollection should update a collection in the state', () => {
+    expect(collections.length).toEqual(3);
     updateCollection(updatedCollectionData, setMockCollections);
     expect(newCollections.length).toEqual(3);
     expect(newCollections.filter(collection => collection.uuid === updatedCollectionData.uuid)[0].name)
@@ -61,8 +67,10 @@ describe('collection mutators', () => {
   })
 
   it('deleteCollection should delete a collection and all associated items from the state', () => {
+    expect(collections.length).toEqual(3);
+    expect(Object.keys(items).length).toEqual(9);
     deleteCollection(existingCollectionData, setMockCollections, setMockItems);
     expect(newCollections.length).toEqual(2);
-    expect(Object.keys(newItems).length).toEqual(6);
+    expect(Object.keys(newItems).length).toEqual(6); // 3 items were associated with deleted collection
   })
 });

--- a/test/stateMutation.test.js
+++ b/test/stateMutation.test.js
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { collections, items } from "@/config/data/splitSampleData.js";
+import {
+  existingItemData,
+  newItemData,
+  updatedItemData,
+  newCollectionData,
+  updatedCollectionData, existingCollectionData
+} from "./mutationData.js";
+
+import { setItem, deleteItem, createCollection, updateCollection, deleteCollection } from "@/common/stateMutation.jsx";
+
+let newCollections;
+let newItems;
+
+function setMockCollections(mutator) {
+  newCollections = mutator(collections);
+}
+
+function setMockItems(mutator) {
+  newItems = mutator(items);
+}
+
+beforeEach(() => {
+  newItems = {};
+  newCollections = [];
+});
+
+describe('item mutators', () => {
+  it('setItem should add a new item to the state', () => {
+    setItem(newItemData, setMockItems);
+    expect(Object.keys(newItems).length).toEqual(10);
+    expect(newItemData.uuid in newItems).toBe(true);
+  })
+
+  it('setItem should update an item in the state', () => {
+    setItem(updatedItemData, setMockItems);
+    expect(Object.keys(newItems).length).toEqual(9);
+    expect(newItems[updatedItemData.uuid].data.password).toEqual(updatedItemData.data.password);
+  })
+
+  it('deleteItem should delete an item from the state', () => {
+    deleteItem(existingItemData, setMockItems);
+    expect(Object.keys(newItems).length).toEqual(8);
+    expect(existingItemData.uuid in newItems).toBe(false);
+  })
+});
+
+describe('collection mutators', () => {
+  it('createCollection should add a new collection to the state', () => {
+    createCollection(newCollectionData, setMockCollections);
+    expect(newCollections.length).toEqual(4);
+    expect(newCollections.filter(collection => collection.uuid === newCollectionData.uuid).length).toEqual(1);
+  })
+
+  it('updateCollection should update a collection in the state', () => {
+    updateCollection(updatedCollectionData, setMockCollections);
+    expect(newCollections.length).toEqual(3);
+    expect(newCollections.filter(collection => collection.uuid === updatedCollectionData.uuid)[0].name)
+      .toEqual(updatedCollectionData.name);
+  })
+
+  it('deleteCollection should delete a collection and all associated items from the state', () => {
+    deleteCollection(existingCollectionData, setMockCollections, setMockItems);
+    expect(newCollections.length).toEqual(2);
+    expect(Object.keys(newItems).length).toEqual(6);
+  })
+});


### PR DESCRIPTION
## Changes

- Add state mutation functions for collections and items
     - `setItem`
          - performs both create and update
     - `deleteItem`
     - `createCollection`
     - `updateCollection`
     - `deleteCollection`
          - deletes both a collection and its associated items

## Usage

The entire object being mutated should be passed to the function, along with the relevant setter function.

`deleteCollection` requires the setters for both collections and items.

```js
import { deleteItem } from "@/common/stateMutation.jsx"

/*
item = {
  data: {
    name: "New York Times",
    url: "https://nytimes.com",
    username: "bob@example.com",
    password: "V4TQhBZRnGmVNYenw",
  },
  uuid: "c7a3a041-8c76-44ed-ba6c-0a0a4be67823",
  vault_collection: "44fc3cb7-efea-42a6-aa31-0bf06b0c9f82",
  created_at: "2023-11-22T19:44:29.280574Z",
  modified_at: "2023-11-22T20:10:03.285150Z",
}
*/

deleteItem(item, setItems);
```

## Testing

- Unit tests

Closes #65 