### PR TITLE
Set anchorOrigin vertical to top for deleteError AlertSnackbar

### DIFF
--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -137,7 +137,7 @@ const SideBar = (props) => {
             <AlertSnackbar
               open={deleteError}
               setOpen={setDeleteError}
-              anchorOrigin={{ vertical: "center", horizontal: "center" }}
+              anchorOrigin={{ vertical: "top", horizontal: "center" }}
               duration={2000}
               message={"Failed to delete item"}
               severity={"error"}


### PR DESCRIPTION
Fixes the following React error that was showing in the console:

```
Warning: Failed prop type: Invalid prop `anchorOrigin.vertical` of value `center` supplied to `ForwardRef(Snackbar2)`, expected one of ["bottom","top"].
```